### PR TITLE
add the include to fix the "error: unexpected type name 'DH': expected expression" compilation error.

### DIFF
--- a/src/DH1080.c
+++ b/src/DH1080.c
@@ -12,6 +12,7 @@
 #include <openssl/rand.h>
 #include <openssl/bn.h>
 #include <openssl/dh.h>
+#include <openssl/engine.h>
 #include <openssl/sha.h>
 #include "DH1080.h"
 


### PR DESCRIPTION
Hello @falsovsky ,

I've tried to compile FISH-irssi on OSX system, but some error have been reported like :

DH1080.c:78:12: warning: implicit declaration of function 'ASN1_dup_of_const' is invalid in C99 [-Wimplicit-function-declaration]
        DH \* dh = DHparams_dup(g_dh);
                  ^
/usr/include/openssl/dh.h:164:25: note: expanded from macro 'DHparams_dup'
# define DHparams_dup(x) ASN1_dup_of_const(DH,i2d_DHparams,d2i_DHparams,x)

```
                    ^
```

DH1080.c:78:12: error: unexpected type name 'DH': expected expression
/usr/include/openssl/dh.h:164:43: note: expanded from macro 'DHparams_dup'
# define DHparams_dup(x) ASN1_dup_of_const(DH,i2d_DHparams,d2i_DHparams,x)

```
                                      ^
```

This error was the fact to missing an include of openssl with only OSX, I guess.

Sincerly,
