### PR TITLE
No longer uses getpass()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Prefix needed to send an unFiSHed message to an encrypted channel or private mes
 String used to mark a FiSHed message
 > default value is "\002>\002 "
 
-### mark_position (boool)
+### mark_position (boolean)
 Defines if the mark should be a prefix (1) or a suffix (0)
 > default value is 1
 	

--- a/README.md
+++ b/README.md
@@ -33,6 +33,56 @@ To load automatically at startup:
 echo "load fish" >> /home/username/.irssi/startup
 </pre>
 
+## Configurations
+FiSH has a few configurations that can be defined via /set on Irssi
+
+### process_outgoing (boolean)
+FiSH outgoing messages
+> default value is 1
+
+### process_incoming (boolean)
+unFiSH incoming messages
+> default value is 1
+
+### auto_keyxchange (boolean)
+Do an automatic key exchange in private messages
+> default value is 1
+
+### nicktracker (boolean)
+
+> default value is 1
+
+### plain_prefix (string)
+Prefix needed to send an unFiSHed message to an encrypted channel or private message. For example:
+<pre>+p Hi there in cleartext</pre>
+> default value is "+p "
+ 
+### mark_encrypted (string)
+String used to mark a FiSHed message
+> default value is "\002>\002 "
+
+### mark_position (boool)
+Defines if the mark should be a prefix (1) or a suffix (0)
+> default value is 1
+	
+### mark_broken_block (string)
+> default value is "\002&\002"
+
+## Commands
+	
+### topic+
+### notice+
+### me+
+### setkey
+### delkey
+### key || showkey
+### keyx
+### setinipw
+### unsetinipw
+### fishlogin
+### fishhelp || helpfish
+
+
 ## Tested on
 * Linux/x86
 * Linux/sparc

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@
 # make
 </pre>
 
+To install to /usr instead of /usr/local
+
+<pre>
+# cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .
+# make
+</pre>
+
+Finally run a **make install** as a privileged user (if needed) to install it. 
+
+Irssi looks for the modules in **/usr/lib/irssi/modules** or **/usr/local/lib/irssi/modules**. The install script copies libfish to **$PREFIX/lib/irssi/modules**.
+
 ## To run
 
 If you installed the module in the default directory, you just need to run the following command inside irssi to load it:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Prefix needed to send an unFiSHed message to an encrypted channel or private mes
 String used to mark a FiSHed message
 > default value is "\002>\002 "
 
-### mark_position (boolean)
+### mark_position (boool)
 Defines if the mark should be a prefix (1) or a suffix (0)
 > default value is 1
 	
@@ -70,18 +70,40 @@ Defines if the mark should be a prefix (1) or a suffix (0)
 
 ## Commands
 	
-### topic+
-### notice+
-### me+
-### setkey
-### delkey
-### key || showkey
-### keyx
-### setinipw
-### unsetinipw
-### fishlogin
-### fishhelp || helpfish
+### /topic+ [message]
+Sets a FiSHed topic in the current channel
 
+### /notice+ [nick/#channel] [message]
+Sends a FiSHed notice to the current window or to target if specified
+
+### /me+ [message]
+Send a FiSHed action to the current window
+
+### /setkey [servertag] [nick/#channel] [key]
+Sets the key used to FiSH the messages for the current window or to the defined target
+
+### /delkey [servertag] [nick/#channel]
+Unsets the key used to FiSH the messages for the current window or to the defined target
+
+### /key [servertag] [nick/#channel] 
+### /showkey [servertag] [nick/#channel]
+Shows the used key to FiSH the messages for the current window or to the defined target
+
+### /keyx
+Forces a DH key exchange in the current window
+
+### /setinipw [password]
+Sets a custom password used to cipher the contents of blow.ini. If this is set its needed to run **/fishlogin** after loading FiSH
+
+### /unsetinipw
+Unsets the custom password used to cipher blow.ini
+
+### /fishlogin
+Reads a blow.ini that is ciphered with a custom password
+
+### /fishhelp
+### /helpfish
+Show a little help inside Irssi
 
 ## Tested on
 * Linux/x86

--- a/src/FiSH.c
+++ b/src/FiSH.c
@@ -1286,8 +1286,6 @@ void authenticated_fish_setup(const char *password, void *rec) {
 	if (strcmp(B64digest, iniPasswordHash) != 0) {
 		printtext(NULL, NULL, MSGLEVEL_CRAP,
 			  "\002FiSH:\002 Wrong blow.ini password entered...");
-		printtext(NULL, NULL, MSGLEVEL_CRAP,
-			  "You must \002/unload fish\002 to try again");
 		return;
 	}
 	printtext(NULL, NULL, MSGLEVEL_CRAP,
@@ -1296,12 +1294,18 @@ void authenticated_fish_setup(const char *password, void *rec) {
 	setup_fish();
 }
 
+void cmd_fish_login(const char *data, SERVER_REC * server, WI_ITEM_REC * item) {
+	keyboard_entry_redirect((SIGNAL_FUNC) authenticated_fish_setup,
+			" --> Please enter your blow.ini password: ",
+			ENTRY_REDIRECT_FLAG_HIDDEN, NULL);
+
+}
 
 void fish_init(void)
 {
-	module_register("fish", "core");
-
 	char iniPasswordHash[50];
+
+	command_bind("fish-login", NULL, (SIGNAL_FUNC) cmd_fish_login);
  
         get_ini_password_hash(sizeof(iniPasswordHash), iniPasswordHash);
  
@@ -1312,10 +1316,11 @@ void fish_init(void)
  
                 setup_fish();
         } else {
-		keyboard_entry_redirect((SIGNAL_FUNC) authenticated_fish_setup,
-					" --> Please enter your blow.ini password: ",
-					ENTRY_REDIRECT_FLAG_HIDDEN, NULL);
+		printtext(NULL, NULL, MSGLEVEL_CRAP,
+				"\002FiSH:\002 Current blow.ini is password protected please do \002/fish-login\002 to decode it.");
         }
+
+	module_register("fish", "core");
 }
  
 

--- a/src/FiSH.c
+++ b/src/FiSH.c
@@ -1354,6 +1354,7 @@ void fish_deinit(void)
 	command_unbind("keyx", (SIGNAL_FUNC) cmd_keyx);
 	command_unbind("setinipw", (SIGNAL_FUNC) cmd_setinipw);
 	command_unbind("unsetinipw", (SIGNAL_FUNC) cmd_unsetinipw);
+	command_unbind("fish-login", (SIGNAL_FUNC) cmd_fish_login);
 
 	command_unbind("fishhelp", (SIGNAL_FUNC) cmd_helpfish);
 	command_unbind("helpfish", (SIGNAL_FUNC) cmd_helpfish);

--- a/src/FiSH.c
+++ b/src/FiSH.c
@@ -678,7 +678,8 @@ static void sig_complete_topic_plus(GList **list, WINDOW_REC *window,
 void cmd_helpfish(const char *arg, SERVER_REC * server, WI_ITEM_REC * item)
 {
 	printtext(NULL, NULL, MSGLEVEL_CRAP,
-		  "\n\002FiSH HELP:\002 For more information read FiSH-irssi.txt :)\n\n"
+		  "\n\002FiSH HELP:\002 For more information read FiSH-irssi.txt :)\n"
+		  "\002NOTE\002: If you have a password defined for blow.ini you will need to first run \002/fishlogin\002\n\n"
 		  " /topic+ <your new topic>\n"
 		  " /notice+ <nick/#channel> <notice message>\n"
 		  " /me+ <your action message>\n"
@@ -1243,9 +1244,6 @@ void setup_fish()
 	command_bind("setinipw", NULL, (SIGNAL_FUNC) cmd_setinipw);
 	command_bind("unsetinipw", NULL, (SIGNAL_FUNC) cmd_unsetinipw);
  
-	command_bind("fishhelp", NULL, (SIGNAL_FUNC) cmd_helpfish);
-	command_bind("helpfish", NULL, (SIGNAL_FUNC) cmd_helpfish);
- 
 	settings_add_bool_module("fish", "fish", "process_outgoing", 1);
 	settings_add_bool_module("fish", "fish", "process_incoming", 1);
 	settings_add_bool_module("fish", "fish", "auto_keyxchange", 1);
@@ -1257,12 +1255,6 @@ void setup_fish()
 	settings_add_str_module("fish", "fish", "plain_prefix", "+p ");
  
 	settings_add_int_module("fish", "fish", "mark_position", 1);
- 
-	printtext(NULL, NULL, MSGLEVEL_CLIENTNOTICE,
-		  "FiSH " FISH_VERSION " - encryption module for irssi loaded!\n"
-		  "URL: https://github.com/falsovsky/FiSH-irssi\n"
-		  "Try /helpfish or /fishhelp for a short command overview");
- 
 }
  
 void get_ini_password_hash(int password_size, char* password) {
@@ -1294,7 +1286,7 @@ void authenticated_fish_setup(const char *password, void *rec) {
 	setup_fish();
 }
 
-void cmd_fish_login(const char *data, SERVER_REC * server, WI_ITEM_REC * item) {
+void cmd_fishlogin(const char *data, SERVER_REC * server, WI_ITEM_REC * item) {
 	keyboard_entry_redirect((SIGNAL_FUNC) authenticated_fish_setup,
 			" --> Please enter your blow.ini password: ",
 			ENTRY_REDIRECT_FLAG_HIDDEN, NULL);
@@ -1305,7 +1297,14 @@ void fish_init(void)
 {
 	char iniPasswordHash[50];
 
-	command_bind("fish-login", NULL, (SIGNAL_FUNC) cmd_fish_login);
+        printtext(NULL, NULL, MSGLEVEL_CLIENTNOTICE,
+		"FiSH " FISH_VERSION " - encryption module for irssi loaded!\n"
+                 "URL: https://github.com/falsovsky/FiSH-irssi\n"
+                 "Try /helpfish or /fishhelp for a short command overview");
+
+	command_bind("fishhelp", NULL, (SIGNAL_FUNC) cmd_helpfish);
+	command_bind("helpfish", NULL, (SIGNAL_FUNC) cmd_helpfish);
+	command_bind("fishlogin", NULL, (SIGNAL_FUNC) cmd_fishlogin);
  
         get_ini_password_hash(sizeof(iniPasswordHash), iniPasswordHash);
  
@@ -1317,7 +1316,7 @@ void fish_init(void)
                 setup_fish();
         } else {
 		printtext(NULL, NULL, MSGLEVEL_CRAP,
-				"\002FiSH:\002 Current blow.ini is password protected please do \002/fish-login\002 to decode it.");
+				"\002FiSH:\002 Current blow.ini is password protected please do \002/fishlogin\002 to decode it.");
         }
 
 	module_register("fish", "core");
@@ -1354,7 +1353,7 @@ void fish_deinit(void)
 	command_unbind("keyx", (SIGNAL_FUNC) cmd_keyx);
 	command_unbind("setinipw", (SIGNAL_FUNC) cmd_setinipw);
 	command_unbind("unsetinipw", (SIGNAL_FUNC) cmd_unsetinipw);
-	command_unbind("fish-login", (SIGNAL_FUNC) cmd_fish_login);
+	command_unbind("fishlogin", (SIGNAL_FUNC) cmd_fishlogin);
 
 	command_unbind("fishhelp", (SIGNAL_FUNC) cmd_helpfish);
 	command_unbind("helpfish", (SIGNAL_FUNC) cmd_helpfish);

--- a/src/module.h
+++ b/src/module.h
@@ -13,6 +13,8 @@
 #include <core/recode.h>
 #include <fe-common/core/printtext.h>
 #include <fe-common/core/window-items.h>
+#include <fe-common/core/keyboard.h>
+#include <fe-common/irc/module-formats.h>
 #include <irc/core/irc.h>
 #include <irc/core/irc-commands.h>
 #include <irc/core/irc-servers.h>


### PR DESCRIPTION
getpass() freezed irssi on openwrt and was also bad in general.

So now FiSH is using the same implementation that irssi uses to ask for the ircop password.

Now if you have a custom blow.ini password youll need to /fishlogin before you can start using fish.

I also updated the readme with all the configuration options and commands descriptions