### PR TITLE
Add missing DH1080_Init call (fix /keyx segfault)

### DIFF
--- a/src/FiSH.c
+++ b/src/FiSH.c
@@ -1305,6 +1305,9 @@ void fish_init(void)
 	command_bind("helpfish", NULL, (SIGNAL_FUNC) cmd_helpfish);
 	command_bind("fishlogin", NULL, (SIGNAL_FUNC) cmd_fishlogin);
  
+	if (DH1080_Init() == FALSE)
+		return;
+
         get_ini_password_hash(sizeof(iniPasswordHash), iniPasswordHash);
  
         if (strlen(iniPasswordHash) != 43) {


### PR DESCRIPTION
The segfault was introduced by commit 850241c that deleted a DH1080_Init() call in FiSH.c. Crash log:

    Program received signal SIGSEGV, Segmentation fault.
    0x00007ffff65163e0 in DH_generate_key () from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
    (gdb) bt
    #0  0x00007ffff65163e0 in DH_generate_key () from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
    #1  0x00007ffff457a754 in DH1080_gen (priv_key=0x7ffff4781b00 "", pub_key=0x7ffff4781840 "")
        at /home/def/FiSH-irssi/src/DH1080.c:81
    #2  0x00007ffff457dde2 in cmd_keyx (target=0x8caaed "def", server=0x8c75b0, item=0x0)
        at /home/def/FiSH-irssi/src/FiSH.c:1070
    #3  0x000000000048e0ba in ?? ()
    #4  0x000000000048e56d in signal_emit ()
    #5  0x000000000047a36e in ?? ()
    #6  0x000000000048e0ba in ?? ()
    #7  0x000000000048e56d in signal_emit ()
    #8  0x000000000041c37b in ?? ()
    #9  0x000000000048e0ba in ?? ()
    #10 0x000000000048e56d in signal_emit ()
    #11 0x000000000044e9e7 in ?? ()
    #12 0x000000000048e0ba in ?? ()
    #13 0x000000000048e56d in signal_emit ()
    #14 0x000000000044f3b3 in key_pressed ()
    #15 0x000000000041bc2e in ?? ()
    #16 0x000000000048e0ba in ?? ()
    #17 0x000000000048e56d in signal_emit ()
    #18 0x000000000041d05e in ?? ()
    #19 0x0000000000480f99 in ?? ()
    #20 0x00007ffff6ac9355 in g_main_dispatch (context=0x6e5800)
        at /tmp/buildd/glib2.0-2.33.12+really2.32.4/./glib/gmain.c:2539
    #21 g_main_context_dispatch (context=context@entry=0x6e5800)
        at /tmp/buildd/glib2.0-2.33.12+really2.32.4/./glib/gmain.c:3075
    #22 0x00007ffff6ac9688 in g_main_context_iterate (context=context@entry=0x6e5800, block=block@entry=1, 
        dispatch=dispatch@entry=1, self=<error reading variable: Unhandled dwarf expression opcode 0xfa>)
        at /tmp/buildd/glib2.0-2.33.12+really2.32.4/./glib/gmain.c:3146
    #23 0x00007ffff6ac9744 in g_main_context_iteration (context=0x6e5800, may_block=1)
        at /tmp/buildd/glib2.0-2.33.12+really2.32.4/./glib/gmain.c:3207
    #24 0x000000000041905c in main ()
    (gdb) f 1
    #1  0x00007ffff457a754 in DH1080_gen (priv_key=0x7ffff4781b00 "", pub_key=0x7ffff4781840 "")
        at /home/def/FiSH-irssi/src/DH1080.c:81
    81		DH_generate_key(dh);
    (gdb) p dh
    $1 = (DH *) 0x0
    (gdb) p g_dh
    $2 = (DH *) 0x0
    (gdb) 

dh and g_dh are NULL pointers because DH1080_Init() is not called. This commit fixes the issue.