### PR TITLE
change the irssi's variable to specify the irssi path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(OPENSSL_FOUND)
 	MESSAGE(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
 ENDIF()
 
-SET(IRSSI_PATH "/usr/include/irssi" PATH "path to irssi include files")
+SET(IRSSI_PATH:PATH "/usr/include/irssi" PATH "path to irssi include files")
 FIND_PATH(irssi_INCLUDE_DIR
 	NAMES irssi-config.h src/common.h
 	PATHS ${IRSSI_PATH} /usr/local/include/irssi


### PR DESCRIPTION
Hello @falsovsky ,

You will find in my patch a small change to make possible the the path overriding via cmake command -DIRSSI_PATH:PATH. 

Before, the command doesn't work because the following message printed :

```
cmake -DIRSSI_PATH:PATH=/Users/mytestuser/irssi/include/irssi/ ..
... some stuff ...
-- Using OpenSSL 1.0.2h
CMake Error at CMakeLists.txt:34 (MESSAGE):
  Could not auto find the irssi include files, please run:

  # cmake -DIRSSI_PATH:PATH=/path/to/irssi/includes .


-- Configuring incomplete, errors occurred!

```


Have a nice day,

Sincerly,

